### PR TITLE
fixed(README.md): package name  in shell command?

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ This plugin is an infinite scroll plugin for React.js, it can help you create an
 ## Installation
 
 ```sh
-npm i react-ivertical-infinite-scrolling --save
+npm i react-vertical-infinite-scrolling --save
 ```
 
 or
 
 ```sh
-yarn add react-ivertical-infinite-scrolling
+yarn add react-vertical-infinite-scrolling
 ```
 
 ## Usage & Guide


### PR DESCRIPTION
When I execute the command `yarn add react-ivertical-infinite-scrolling`,  there is an error coming out  
`error An unexpected error occurred: "https://registry.npmjs.org/react-ivertical-infinite-scrolling: Not found".`

use `yarn add react-vertical-infinite-scrolling` instead...